### PR TITLE
Apply spotless license headers and formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Initial application of Spotless licence headers and formatting
+74d23222463af1ad33f0573c4acd0b2cea2a0164

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,11 +4,10 @@ plugins {
 }
 
 group = "com.opencastsoftware"
+
 description = "WebAssembly toolkit for Java"
 
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(11))
-}
+java { toolchain.languageVersion.set(JavaLanguageVersion.of(11)) }
 
 dependencies {
     compileOnly(libs.jetBrainsAnnotations)
@@ -62,26 +61,21 @@ mavenPublishing {
     }
 }
 
-tasks.named<Test>("test") {
-    useJUnitPlatform {
-        includeEngines("junit-jupiter", "jqwik")
-    }
-}
+tasks.named<Test>("test") { useJUnitPlatform { includeEngines("junit-jupiter", "jqwik") } }
 
 // Create an integration test source set and configuration
 testing {
     suites {
-        val integrationTest by registering(JvmTestSuite::class) {
-            dependencies {
-                implementation(project())
-                implementation(libs.apacheCommonsLang)
-                implementation(libs.junitJupiter)
-                implementation(libs.hamcrest)
+        val integrationTest by
+            registering(JvmTestSuite::class) {
+                dependencies {
+                    implementation(project())
+                    implementation(libs.apacheCommonsLang)
+                    implementation(libs.junitJupiter)
+                    implementation(libs.hamcrest)
+                }
             }
-        }
     }
 }
 
-tasks.check {
-    dependsOn(testing.suites.named("integrationTest"))
-}
+tasks.check { dependsOn(testing.suites.named("integrationTest")) }

--- a/src/integrationTest/java/com/opencastsoftware/wasm4j/WasmDisComparisonTest.java
+++ b/src/integrationTest/java/com/opencastsoftware/wasm4j/WasmDisComparisonTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j;
 
 import com.opencastsoftware.wasm4j.encoding.binary.WasmBinaryEncoder;

--- a/src/main/java/com/opencastsoftware/wasm4j/BaseExpression.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/BaseExpression.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j;
 
 import com.opencastsoftware.wasm4j.instructions.Instruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/ConstantExpression.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/ConstantExpression.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j;
 
 import com.opencastsoftware.wasm4j.instructions.ConstantInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/Data.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/Data.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j;
 
 public class Data {

--- a/src/main/java/com/opencastsoftware/wasm4j/Elem.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/Elem.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j;
 
 import com.opencastsoftware.wasm4j.types.RefType;

--- a/src/main/java/com/opencastsoftware/wasm4j/Export.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/Export.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j;
 
 public class Export {

--- a/src/main/java/com/opencastsoftware/wasm4j/Expression.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/Expression.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j;
 
 import com.opencastsoftware.wasm4j.instructions.Instruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/Func.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/Func.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j;
 
 import com.opencastsoftware.wasm4j.types.ValType;

--- a/src/main/java/com/opencastsoftware/wasm4j/Global.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/Global.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j;
 
 import com.opencastsoftware.wasm4j.types.GlobalType;

--- a/src/main/java/com/opencastsoftware/wasm4j/Import.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/Import.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j;
 
 import com.opencastsoftware.wasm4j.types.GlobalType;

--- a/src/main/java/com/opencastsoftware/wasm4j/IndexType.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/IndexType.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j;
 
 public enum IndexType {

--- a/src/main/java/com/opencastsoftware/wasm4j/Module.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/Module.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j;
 
 import com.opencastsoftware.wasm4j.types.FuncType;

--- a/src/main/java/com/opencastsoftware/wasm4j/Table.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/Table.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j;
 
 import com.opencastsoftware.wasm4j.types.TableType;

--- a/src/main/java/com/opencastsoftware/wasm4j/encoding/WasmEncoder.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/encoding/WasmEncoder.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.encoding;
 
 import com.opencastsoftware.wasm4j.*;

--- a/src/main/java/com/opencastsoftware/wasm4j/encoding/binary/ConstantInstructionBinaryEncodingVisitor.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/encoding/binary/ConstantInstructionBinaryEncodingVisitor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.encoding.binary;
 
 import com.opencastsoftware.wasm4j.ConstantExpression;

--- a/src/main/java/com/opencastsoftware/wasm4j/encoding/binary/InstructionBinaryEncodingVisitor.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/encoding/binary/InstructionBinaryEncodingVisitor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.encoding.binary;
 
 import com.opencastsoftware.wasm4j.Expression;

--- a/src/main/java/com/opencastsoftware/wasm4j/encoding/binary/LEB128.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/encoding/binary/LEB128.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.encoding.binary;
 
 import java.io.IOException;

--- a/src/main/java/com/opencastsoftware/wasm4j/encoding/binary/Opcode.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/encoding/binary/Opcode.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.encoding.binary;
 
 public enum Opcode {

--- a/src/main/java/com/opencastsoftware/wasm4j/encoding/binary/SectionId.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/encoding/binary/SectionId.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.encoding.binary;
 
 public enum SectionId {

--- a/src/main/java/com/opencastsoftware/wasm4j/encoding/binary/TypeOpcode.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/encoding/binary/TypeOpcode.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.encoding.binary;
 
 public enum TypeOpcode {

--- a/src/main/java/com/opencastsoftware/wasm4j/encoding/binary/WasmBinaryEncoder.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/encoding/binary/WasmBinaryEncoder.java
@@ -1,7 +1,11 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.encoding.binary;
 
-import com.opencastsoftware.wasm4j.Module;
 import com.opencastsoftware.wasm4j.*;
+import com.opencastsoftware.wasm4j.Module;
 import com.opencastsoftware.wasm4j.encoding.WasmEncoder;
 import com.opencastsoftware.wasm4j.types.FuncType;
 import com.opencastsoftware.wasm4j.types.MemType;

--- a/src/main/java/com/opencastsoftware/wasm4j/encoding/binary/WasmTypeBinaryEncodingVisitor.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/encoding/binary/WasmTypeBinaryEncodingVisitor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.encoding.binary;
 
 import com.opencastsoftware.wasm4j.types.*;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/ConstantInstruction.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/ConstantInstruction.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions;
 
 public interface ConstantInstruction extends Instruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/ConstantInstructionVisitor.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/ConstantInstructionVisitor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions;
 
 import com.opencastsoftware.wasm4j.ConstantExpression;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/Instruction.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/Instruction.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions;
 
 public interface Instruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/InstructionVisitor.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/InstructionVisitor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions;
 
 import com.opencastsoftware.wasm4j.Expression;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/control/Block.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/control/Block.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.control;
 
 import com.opencastsoftware.wasm4j.instructions.Instruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/control/Branch.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/control/Branch.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.control;
 
 public class Branch implements ControlInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/control/BranchIf.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/control/BranchIf.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.control;
 
 public class BranchIf implements ControlInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/control/BranchOnNonNull.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/control/BranchOnNonNull.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.control;
 
 public class BranchOnNonNull implements ControlInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/control/BranchOnNull.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/control/BranchOnNull.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.control;
 
 public class BranchOnNull implements ControlInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/control/BranchTable.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/control/BranchTable.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.control;
 
 public class BranchTable implements ControlInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/control/Call.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/control/Call.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.control;
 
 public class Call implements ControlInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/control/CallIndirect.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/control/CallIndirect.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.control;
 
 public class CallIndirect implements ControlInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/control/CallRef.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/control/CallRef.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.control;
 
 public class CallRef implements ControlInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/control/ControlInstruction.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/control/ControlInstruction.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.control;
 
 import com.opencastsoftware.wasm4j.instructions.Instruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/control/ControlInstructionVisitor.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/control/ControlInstructionVisitor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.control;
 
 public interface ControlInstructionVisitor<T extends Exception> {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/control/If.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/control/If.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.control;
 
 import com.opencastsoftware.wasm4j.instructions.Instruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/control/Loop.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/control/Loop.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.control;
 
 import com.opencastsoftware.wasm4j.instructions.Instruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/control/Nop.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/control/Nop.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.control;
 
 public enum Nop implements ControlInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/control/Return.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/control/Return.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.control;
 
 public enum Return implements ControlInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/control/Unreachable.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/control/Unreachable.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.control;
 
 public enum Unreachable implements ControlInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/DataDrop.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/DataDrop.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.memory;
 
 public class DataDrop implements MemoryInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/F32Load.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/F32Load.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.memory;
 
 public class F32Load implements MemArgInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/F32Store.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/F32Store.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.memory;
 
 public class F32Store implements MemArgInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/F64Load.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/F64Load.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.memory;
 
 public class F64Load implements MemArgInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/F64Store.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/F64Store.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.memory;
 
 public class F64Store implements MemArgInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/I32Load.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/I32Load.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.memory;
 
 public class I32Load implements MemArgInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/I32Store.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/I32Store.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.memory;
 
 public class I32Store implements MemArgInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/I64Load.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/I64Load.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.memory;
 
 public class I64Load implements MemArgInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/I64Store.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/I64Store.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.memory;
 
 public class I64Store implements MemArgInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/MemArgInstruction.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/MemArgInstruction.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.memory;
 
 public interface MemArgInstruction extends MemoryInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/MemoryCopy.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/MemoryCopy.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.memory;
 
 public class MemoryCopy implements MemoryInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/MemoryFill.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/MemoryFill.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.memory;
 
 public class MemoryFill implements MemoryInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/MemoryGrow.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/MemoryGrow.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.memory;
 
 public class MemoryGrow implements MemoryInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/MemoryInit.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/MemoryInit.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.memory;
 
 public class MemoryInit implements MemoryInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/MemoryInstruction.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/MemoryInstruction.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.memory;
 
 import com.opencastsoftware.wasm4j.instructions.Instruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/MemoryInstructionVisitor.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/MemoryInstructionVisitor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.memory;
 
 public interface MemoryInstructionVisitor<T extends Exception> {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/MemorySize.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/memory/MemorySize.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.memory;
 
 public class MemorySize implements MemoryInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/NumericInstruction.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/NumericInstruction.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric;
 
 import com.opencastsoftware.wasm4j.instructions.Instruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/NumericInstructionVisitor.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/NumericInstructionVisitor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.floating.F32Const;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/F32Const.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/F32Const.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating;
 
 import com.opencastsoftware.wasm4j.instructions.ConstantInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/F64Const.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/F64Const.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating;
 
 import com.opencastsoftware.wasm4j.instructions.ConstantInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F32Add.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F32Add.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F32Copysign.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F32Copysign.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F32Div.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F32Div.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F32Max.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F32Max.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F32Min.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F32Min.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F32Mul.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F32Mul.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F32Sub.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F32Sub.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F64Add.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F64Add.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F64Copysign.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F64Copysign.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F64Div.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F64Div.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F64Max.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F64Max.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F64Min.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F64Min.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F64Mul.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F64Mul.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F64Sub.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/binary/F64Sub.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F32Eq.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F32Eq.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F32Ge.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F32Ge.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F32Gt.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F32Gt.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F32Le.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F32Le.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F32Lt.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F32Lt.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F32Ne.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F32Ne.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F64Eq.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F64Eq.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F64Ge.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F64Ge.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F64Gt.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F64Gt.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F64Le.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F64Le.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F64Lt.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F64Lt.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F64Ne.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/relational/F64Ne.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F32Abs.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F32Abs.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F32Ceil.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F32Ceil.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F32Floor.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F32Floor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F32Nearest.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F32Nearest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F32Neg.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F32Neg.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F32Sqrt.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F32Sqrt.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F32Trunc.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F32Trunc.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F64Abs.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F64Abs.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F64Ceil.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F64Ceil.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F64Floor.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F64Floor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F64Nearest.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F64Nearest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F64Neg.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F64Neg.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F64Sqrt.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F64Sqrt.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F64Trunc.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/floating/unary/F64Trunc.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.floating.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/I32Const.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/I32Const.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer;
 
 import com.opencastsoftware.wasm4j.instructions.ConstantInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/I64Const.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/I64Const.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer;
 
 import com.opencastsoftware.wasm4j.instructions.ConstantInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32Add.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32Add.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32And.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32And.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32DivSigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32DivSigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32DivUnsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32DivUnsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32Mul.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32Mul.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32Or.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32Or.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32RemSigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32RemSigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32RemUnsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32RemUnsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32Rotl.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32Rotl.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32Rotr.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32Rotr.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32Shl.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32Shl.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32ShrSigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32ShrSigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32ShrUnsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32ShrUnsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32Sub.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32Sub.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32Xor.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I32Xor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64Add.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64Add.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64And.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64And.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64DivSigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64DivSigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64DivUnsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64DivUnsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64Mul.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64Mul.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64Or.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64Or.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64RemSigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64RemSigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64RemUnsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64RemUnsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64Rotl.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64Rotl.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64Rotr.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64Rotr.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64Shl.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64Shl.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64ShrSigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64ShrSigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64ShrUnsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64ShrUnsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64Sub.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64Sub.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64Xor.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/binary/I64Xor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F32ConvertI32Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F32ConvertI32Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F32ConvertI32Unsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F32ConvertI32Unsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F32ConvertI64Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F32ConvertI64Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F32ConvertI64Unsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F32ConvertI64Unsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F32DemoteF64.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F32DemoteF64.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F32ReinterpretI32.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F32ReinterpretI32.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F64ConvertI32Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F64ConvertI32Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F64ConvertI32Unsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F64ConvertI32Unsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F64ConvertI64Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F64ConvertI64Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F64ConvertI64Unsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F64ConvertI64Unsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F64PromoteF32.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F64PromoteF32.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F64ReinterpretI64.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/F64ReinterpretI64.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32Extend16Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32Extend16Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32Extend8Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32Extend8Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32ReinterpretF32.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32ReinterpretF32.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32TruncF32Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32TruncF32Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32TruncF32Unsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32TruncF32Unsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32TruncF64Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32TruncF64Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32TruncF64Unsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32TruncF64Unsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32TruncSatF32Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32TruncSatF32Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32TruncSatF32Unsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32TruncSatF32Unsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32TruncSatF64Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32TruncSatF64Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32TruncSatF64Unsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32TruncSatF64Unsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32WrapI64.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I32WrapI64.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64Extend16Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64Extend16Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64Extend32Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64Extend32Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64Extend8Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64Extend8Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64ExtendI32Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64ExtendI32Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64ExtendI32Unsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64ExtendI32Unsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64ReinterpretF64.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64ReinterpretF64.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64TruncF32Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64TruncF32Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64TruncF32Unsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64TruncF32Unsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64TruncF64Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64TruncF64Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64TruncF64Unsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64TruncF64Unsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64TruncSatF32Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64TruncSatF32Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64TruncSatF32Unsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64TruncSatF32Unsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64TruncSatF64Signed.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64TruncSatF64Signed.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64TruncSatF64Unsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/conversion/I64TruncSatF64Unsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.conversion;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32Eq.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32Eq.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32GeSigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32GeSigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32GeUnsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32GeUnsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32GtSigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32GtSigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32GtUnsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32GtUnsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32LeSigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32LeSigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32LeUnsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32LeUnsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32LtSigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32LtSigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32LtUnsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32LtUnsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32Ne.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I32Ne.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64Eq.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64Eq.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64GeSigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64GeSigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64GeUnsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64GeUnsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64GtSigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64GtSigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64GtUnsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64GtUnsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64LeSigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64LeSigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64LeUnsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64LeUnsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64LtSigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64LtSigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64LtUnsigned.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64LtUnsigned.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64Ne.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/relational/I64Ne.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.relational;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/test/I32Eqz.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/test/I32Eqz.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.test;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/test/I64Eqz.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/test/I64Eqz.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.test;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/unary/I32Clz.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/unary/I32Clz.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/unary/I32Ctz.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/unary/I32Ctz.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/unary/I32Popcnt.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/unary/I32Popcnt.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/unary/I64Clz.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/unary/I64Clz.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/unary/I64Ctz.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/unary/I64Ctz.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/unary/I64Popcnt.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/numeric/integer/unary/I64Popcnt.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.numeric.integer.unary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/parametric/Drop.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/parametric/Drop.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.parametric;
 
 public enum Drop implements ParametricInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/parametric/ParametricInstruction.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/parametric/ParametricInstruction.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.parametric;
 
 import com.opencastsoftware.wasm4j.instructions.Instruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/parametric/ParametricInstructionVisitor.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/parametric/ParametricInstructionVisitor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.parametric;
 
 public interface ParametricInstructionVisitor<T extends Exception> {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/parametric/Select.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/parametric/Select.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.parametric;
 
 import com.opencastsoftware.wasm4j.types.ValType;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/reference/RefAsNonNull.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/reference/RefAsNonNull.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.reference;
 
 public enum RefAsNonNull implements ReferenceInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/reference/RefFunc.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/reference/RefFunc.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.reference;
 
 import com.opencastsoftware.wasm4j.instructions.ConstantInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/reference/RefIsNull.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/reference/RefIsNull.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.reference;
 
 public enum RefIsNull implements ReferenceInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/reference/RefNull.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/reference/RefNull.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.reference;
 
 import com.opencastsoftware.wasm4j.instructions.ConstantInstruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/reference/ReferenceInstruction.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/reference/ReferenceInstruction.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.reference;
 
 import com.opencastsoftware.wasm4j.instructions.Instruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/reference/ReferenceInstructionVisitor.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/reference/ReferenceInstructionVisitor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.reference;
 
 public interface ReferenceInstructionVisitor<T extends Exception> {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/table/ElemDrop.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/table/ElemDrop.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.table;
 
 public class ElemDrop implements TableInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableCopy.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableCopy.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.table;
 
 public class TableCopy implements TableInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableFill.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableFill.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.table;
 
 public class TableFill implements TableInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableGet.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableGet.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.table;
 
 public class TableGet implements TableInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableGrow.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableGrow.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.table;
 
 public class TableGrow implements TableInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableInit.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableInit.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.table;
 
 public class TableInit implements TableInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableInstruction.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableInstruction.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.table;
 
 import com.opencastsoftware.wasm4j.instructions.Instruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableInstructionVisitor.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableInstructionVisitor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.table;
 
 public interface TableInstructionVisitor<T extends Exception> {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableSet.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableSet.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.table;
 
 public class TableSet implements TableInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableSize.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/table/TableSize.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.table;
 
 public class TableSize implements TableInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/variable/GlobalGet.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/variable/GlobalGet.java
@@ -1,8 +1,11 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.variable;
 
 import com.opencastsoftware.wasm4j.instructions.ConstantInstruction;
 import com.opencastsoftware.wasm4j.instructions.ConstantInstructionVisitor;
-import com.opencastsoftware.wasm4j.instructions.InstructionVisitor;
 
 public class GlobalGet implements VariableInstruction, ConstantInstruction {
     private final int globalIndex;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/variable/GlobalSet.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/variable/GlobalSet.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.variable;
 
 public class GlobalSet implements VariableInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/variable/LocalGet.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/variable/LocalGet.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.variable;
 
 public class LocalGet implements VariableInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/variable/LocalSet.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/variable/LocalSet.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.variable;
 
 public class LocalSet implements VariableInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/variable/LocalTee.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/variable/LocalTee.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.variable;
 
 public class LocalTee implements VariableInstruction {

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/variable/VariableInstruction.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/variable/VariableInstruction.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.variable;
 
 import com.opencastsoftware.wasm4j.instructions.Instruction;

--- a/src/main/java/com/opencastsoftware/wasm4j/instructions/variable/VariableInstructionVisitor.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/instructions/variable/VariableInstructionVisitor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.instructions.variable;
 
 public interface VariableInstructionVisitor<T extends Exception> {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/BlockType.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/BlockType.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public interface BlockType extends WasmType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/ExternType.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/ExternType.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 import java.util.List;

--- a/src/main/java/com/opencastsoftware/wasm4j/types/F32Type.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/F32Type.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public enum F32Type implements NumType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/F64Type.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/F64Type.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public enum F64Type implements NumType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/FuncType.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/FuncType.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 import java.util.List;

--- a/src/main/java/com/opencastsoftware/wasm4j/types/GlobalType.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/GlobalType.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public class GlobalType implements ExternType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/HeapExternType.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/HeapExternType.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public enum HeapExternType implements HeapType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/HeapFuncType.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/HeapFuncType.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public enum HeapFuncType implements HeapType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/HeapType.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/HeapType.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public interface HeapType extends WasmType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/I32Type.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/I32Type.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public enum I32Type implements NumType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/I64Type.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/I64Type.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public enum I64Type implements NumType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/Limits.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/Limits.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/com/opencastsoftware/wasm4j/types/MemType.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/MemType.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public class MemType implements ExternType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/NumType.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/NumType.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public interface NumType extends ValType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/RefType.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/RefType.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public class RefType implements ValType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/TableType.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/TableType.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public class TableType implements ExternType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/TypeId.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/TypeId.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public class TypeId implements HeapType, BlockType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/V128Type.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/V128Type.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public enum V128Type implements VecType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/ValType.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/ValType.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public interface ValType extends BlockType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/VecType.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/VecType.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public interface VecType extends ValType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/WasmType.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/WasmType.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public interface WasmType {

--- a/src/main/java/com/opencastsoftware/wasm4j/types/WasmTypeVisitor.java
+++ b/src/main/java/com/opencastsoftware/wasm4j/types/WasmTypeVisitor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.types;
 
 public interface WasmTypeVisitor<T extends Exception> {

--- a/src/test/java/com/opencastsoftware/wasm4j/encoding/LEB128Test.java
+++ b/src/test/java/com/opencastsoftware/wasm4j/encoding/LEB128Test.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.encoding;
 
 import com.opencastsoftware.wasm4j.encoding.binary.LEB128;

--- a/src/test/java/com/opencastsoftware/wasm4j/encoding/binary/ConstantInstructionBinaryEncodingVisitorTest.java
+++ b/src/test/java/com/opencastsoftware/wasm4j/encoding/binary/ConstantInstructionBinaryEncodingVisitorTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.encoding.binary;
 
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;

--- a/src/test/java/com/opencastsoftware/wasm4j/encoding/binary/InstructionBinaryEncodingVisitorTest.java
+++ b/src/test/java/com/opencastsoftware/wasm4j/encoding/binary/InstructionBinaryEncodingVisitorTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.encoding.binary;
 
 import com.opencastsoftware.wasm4j.instructions.control.ControlInstruction;

--- a/src/test/java/com/opencastsoftware/wasm4j/encoding/binary/WasmBinaryEncoderTest.java
+++ b/src/test/java/com/opencastsoftware/wasm4j/encoding/binary/WasmBinaryEncoderTest.java
@@ -1,7 +1,11 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.encoding.binary;
 
-import com.opencastsoftware.wasm4j.Module;
 import com.opencastsoftware.wasm4j.*;
+import com.opencastsoftware.wasm4j.Module;
 import com.opencastsoftware.wasm4j.instructions.numeric.NumericInstruction;
 import com.opencastsoftware.wasm4j.instructions.reference.ReferenceInstruction;
 import com.opencastsoftware.wasm4j.instructions.variable.VariableInstruction;

--- a/src/test/java/com/opencastsoftware/wasm4j/encoding/binary/WasmTypeBinaryEncodingVisitorTest.java
+++ b/src/test/java/com/opencastsoftware/wasm4j/encoding/binary/WasmTypeBinaryEncodingVisitorTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.wasm4j.encoding.binary;
 
 import com.opencastsoftware.wasm4j.types.*;


### PR DESCRIPTION
Applies [spotless](https://github.com/diffplug/spotless) license header and formatting steps.